### PR TITLE
Initialize default gain for TAPS (no explicit gain)

### DIFF
--- a/module_avdsp/encoder/dsp_basiccreate.c
+++ b/module_avdsp/encoder/dsp_basiccreate.c
@@ -1943,6 +1943,7 @@ nextline:
                     if (l->s.type != _empty) fatalErrorNum(12);
                     l->s.type = label_taps;
                     l->s.address = dspMem_LocationMultiple(0);
+                    gain = 1.0;  // default gain if not specified
                     int bracket = searchDelimiter( &p, "(" );
                     if (bracket) {
                         searchExpressionRangeError( &p, &gain, _tvalue64 );


### PR DESCRIPTION
Bug: When a TAPS block had no (gain), the gain variable was uninitialized, so FIR coefficients were multiplied by garbage (often 0), yielding all-zero output.

Fix: Default gain = 1.0 before parsing the optional (gain) syntax.

Effect: Correct coefficients when using the simple form label TAPS "filename.txt".

Impacted: DSP_WFIR and DSP_FIR with TAPS loaded from files without explicit gain.